### PR TITLE
Add dependency on importlib_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     license='BSD',
     packages=['safecheck'],
     entry_points={'console_scripts': ['safecheck = safecheck.safecheck:main']},
-    install_requires=['lxml'],
+    install_requires=['lxml', "importlib_resources>=1.3.0; python_version < '3.9'"],
     package_data={"safecheck": ["xsd/*.xsd"]}
 )


### PR DESCRIPTION
Only needed for old Python versions (< 3.9)